### PR TITLE
Fix button overlap on iPad Mini

### DIFF
--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -51,6 +51,7 @@
   align-items: center;
   gap: 1.5rem;
   flex-wrap: nowrap;
+  justify-content: flex-end;
 }
 
 .header-nav {
@@ -58,6 +59,7 @@
   align-items: center;
   gap: 1rem;
   flex-shrink: 0;
+  justify-content: center;
 }
 
 .header-nav .nav-btn {
@@ -80,6 +82,7 @@
   min-width: fit-content;
   height: auto;
   line-height: 1.2;
+  flex-shrink: 0;
 }
 
 .header-nav .nav-btn:hover {
@@ -112,6 +115,9 @@
   border: 1px solid rgba(255, 255, 255, 0.2);
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   white-space: nowrap;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .user-menu {
@@ -189,7 +195,7 @@
   
   .header-right {
     flex-direction: column !important;
-    gap: 0.75rem;
+    gap: 1rem;
     width: 100%;
     align-items: center !important;
   }
@@ -197,12 +203,14 @@
   .header-nav {
     justify-content: center !important;
     order: 1;
+    gap: 1rem;
   }
   
   .header-nav .nav-btn {
     padding: 0.65rem 1.25rem;
     font-size: 0.9rem;
     min-width: fit-content;
+    margin: 0 0.25rem;
   }
   
   .header-date {
@@ -210,6 +218,7 @@
     min-width: auto !important;
     text-align: center;
     order: 2;
+    margin: 0.5rem 0;
   }
   
   .user-menu {
@@ -219,6 +228,92 @@
   
   .user-name {
     max-width: 120px;
+  }
+}
+
+/* Specific iPad Mini and tablet optimizations */
+@media (min-width: 768px) and (max-width: 1024px) {
+  .header-content {
+    padding: 0 2rem;
+  }
+  
+  .header-right {
+    gap: 1.25rem;
+  }
+  
+  .header-nav {
+    gap: 1.25rem;
+  }
+  
+  .header-nav .nav-btn {
+    padding: 0.75rem 1.5rem;
+    font-size: 0.95rem;
+    margin: 0 0.5rem;
+  }
+  
+  .header-date {
+    font-size: 1rem;
+    padding: 0.75rem 1.5rem;
+    margin: 0.75rem 0;
+  }
+}
+
+/* Safari-specific optimizations for iPad Mini */
+@supports (-webkit-appearance: none) {
+  @media (min-width: 768px) and (max-width: 1024px) {
+    .header-nav .nav-btn {
+      -webkit-transform: translateZ(0);
+      transform: translateZ(0);
+      -webkit-backface-visibility: hidden;
+      backface-visibility: hidden;
+    }
+    
+    .header-date {
+      -webkit-transform: translateZ(0);
+      transform: translateZ(0);
+      -webkit-backface-visibility: hidden;
+      backface-visibility: hidden;
+    }
+  }
+}
+
+/* Additional iPad Mini specific fixes */
+@media (min-width: 768px) and (max-width: 1024px) and (orientation: portrait) {
+  .header-nav {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+  }
+  
+  .header-nav .nav-btn {
+    flex: 0 0 auto;
+    min-width: 140px;
+    max-width: 180px;
+  }
+  
+  .header-date {
+    width: auto;
+    max-width: 300px;
+    word-wrap: break-word;
+    white-space: normal;
+  }
+}
+
+/* Extra safety measures for iPad Mini Safari */
+@media (min-width: 768px) and (max-width: 1024px) {
+  .header-nav .nav-btn {
+    position: relative;
+    z-index: 1;
+  }
+  
+  .header-date {
+    position: relative;
+    z-index: 1;
+  }
+  
+  /* Ensure buttons don't overlap */
+  .header-nav .nav-btn + .nav-btn {
+    margin-left: 0.5rem;
   }
 }
 


### PR DESCRIPTION
Implement iPad Mini and Safari-specific CSS to resolve overlapping navigation buttons and date display.